### PR TITLE
CVE-2020-10663 bump json dependency to ~> 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'json', '~> 1.4'
+gem 'json', '~> 2.3'
 
 gem 'rake', '~> 10.0', :group => [:test, :development]
 

--- a/stomp_out.gemspec
+++ b/stomp_out.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Lee Kirchhoff"]
-  s.date = "2015-02-13"
+  s.date = "2020-03-19"
   s.description = "This implementation of STOMP is aimed at environments where a network connection, such as a WebSocket or TCP socket, is created and then raw data from that connection is passed to/from the STOMP client or server messaging layer provided by this gem."
   s.email = "support@rightscale.com"
   s.extra_rdoc_files = [
@@ -47,14 +47,14 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<json>, ["~> 1.4"])
+      s.add_runtime_dependency(%q<json>, ["~> 2.3"])
       s.add_development_dependency(%q<rake>, ["~> 10.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 2.0"])
       s.add_development_dependency(%q<ruby-debug>, [">= 0"])
       s.add_development_dependency(%q<pry>, [">= 0"])
       s.add_development_dependency(%q<pry-byebug>, [">= 0"])
     else
-      s.add_dependency(%q<json>, ["~> 1.4"])
+      s.add_dependency(%q<json>, ["~> 2.3"])
       s.add_dependency(%q<rake>, ["~> 10.0"])
       s.add_dependency(%q<jeweler>, ["~> 2.0"])
       s.add_dependency(%q<ruby-debug>, [">= 0"])
@@ -62,7 +62,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<pry-byebug>, [">= 0"])
     end
   else
-    s.add_dependency(%q<json>, ["~> 1.4"])
+    s.add_dependency(%q<json>, ["~> 2.3"])
     s.add_dependency(%q<rake>, ["~> 10.0"])
     s.add_dependency(%q<jeweler>, ["~> 2.0"])
     s.add_dependency(%q<ruby-debug>, [">= 0"])


### PR DESCRIPTION
Bumps `json` gem dependency to `~> 2.3` in order to resolve [CVE-2020-10663](https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/)